### PR TITLE
[WIP] Devirtualize auto generated destructor calls for arrays

### DIFF
--- a/gcc/cp/init.cc
+++ b/gcc/cp/init.cc
@@ -4112,8 +4112,8 @@ build_vec_delete_1 (location_t loc, tree base, tree maxindex, tree type,
       if (type_build_dtor_call (type))
 	{
 	  tmp = build_delete (loc, ptype, base, sfk_complete_destructor,
-			      LOOKUP_NORMAL|LOOKUP_DESTRUCTOR, 1,
-			      complain);
+			      LOOKUP_NORMAL|LOOKUP_DESTRUCTOR|LOOKUP_NONVIRTUAL,
+			      1, complain);
 	  if (tmp == error_mark_node)
 	    return error_mark_node;
 	}
@@ -4143,8 +4143,8 @@ build_vec_delete_1 (location_t loc, tree base, tree maxindex, tree type,
     return error_mark_node;
   body = build_compound_expr (loc, body, tmp);
   tmp = build_delete (loc, ptype, tbase, sfk_complete_destructor,
-		      LOOKUP_NORMAL|LOOKUP_DESTRUCTOR, 1,
-		      complain);
+		      LOOKUP_NORMAL|LOOKUP_DESTRUCTOR|LOOKUP_NONVIRTUAL,
+		      1, complain);
   if (tmp == error_mark_node)
     return error_mark_node;
   body = build_compound_expr (loc, body, tmp);

--- a/gcc/testsuite/g++.dg/devirt-array-destructor-1.C
+++ b/gcc/testsuite/g++.dg/devirt-array-destructor-1.C
@@ -1,0 +1,26 @@
+// PR c++/110057
+/* { dg-do run } */
+/* Virtual calls should be devirtualized because we know dynamic type of object in array at compile time */
+/* { dg-options "-O3 -fdump-tree-optimized -fno-inline"  } */
+
+class A
+{
+public:
+  virtual ~A()
+  {
+  }
+};
+
+class B : public A
+{
+public:
+  virtual ~B()
+  {
+  }
+};
+
+int main()
+{
+  B b[10];
+  return 0;
+}

--- a/gcc/testsuite/g++.dg/devirt-array-destructor-2.C
+++ b/gcc/testsuite/g++.dg/devirt-array-destructor-2.C
@@ -1,0 +1,27 @@
+// PR c++/110057
+/* { dg-do run } */
+/* Virtual calls should be devirtualized because we know dynamic type of object in array at compile time */
+/* { dg-options "-O3 -fdump-tree-optimized -fno-inline"  } */
+
+class A
+{
+public:
+  virtual ~A()
+  {
+  }
+};
+
+class B : public A
+{
+public:
+  virtual ~B()
+  {
+  }
+};
+
+int main()
+{
+  B* ptr = new B[10];
+  delete[] ptr;
+  return 0;
+}

--- a/gcc/testsuite/g++.dg/warn/pr83054-2.C
+++ b/gcc/testsuite/g++.dg/warn/pr83054-2.C
@@ -10,7 +10,7 @@
 #endif
 
 extern "C" int printf (const char *, ...);
-struct foo
+struct foo // { dg-warning "final would enable devirtualization of 1 call" }
 {
   static int count;
   void print (int i, int j) { printf ("foo[%d][%d] = %d\n", i, j, x); }
@@ -29,19 +29,15 @@ int foo::count;
 
 int main ()
 {
-  {
-    foo array[3][3];
-    for (int i = 0; i < 3; i++)
-      {
-	for (int j = 0; j < 3; j++)
-	  {
-	    printf("&a[%d][%d] = %x\n", i, j, (void *)&array[i][j]);
-	  }
-      }
-      // The count should be nine, if not, fail the test.
-      if (foo::count != 9)
-	return 1;
-  }
+  foo *arr[9];
+  for (int i = 0; i < 9; ++i)
+    arr[i] = new foo();
+  if (foo::count != 9)
+    return 1;
+  for (int i = 0; i < 9; ++i)
+    arr[i]->print(i / 3, i % 3);
+  for (int i = 0; i < 9; ++i)
+    delete arr[i];
   if (foo::count != 0)
     return 1;
   return 0;


### PR DESCRIPTION
1. Devirtualize auto generated code destructor calls for array

TODO

1. Devirtualize subscripting and subsequent function calls for array
2. Devirtualize function call & dtor for vector, hopefully via same mechanism in the ipa