### PR TITLE
Devirtualize array access

### DIFF
--- a/gcc/cp/init.cc
+++ b/gcc/cp/init.cc
@@ -4112,8 +4112,8 @@ build_vec_delete_1 (location_t loc, tree base, tree maxindex, tree type,
       if (type_build_dtor_call (type))
 	{
 	  tmp = build_delete (loc, ptype, base, sfk_complete_destructor,
-			      LOOKUP_NORMAL|LOOKUP_DESTRUCTOR, 1,
-			      complain);
+			      LOOKUP_NORMAL|LOOKUP_DESTRUCTOR|LOOKUP_NONVIRTUAL,
+			      1, complain);
 	  if (tmp == error_mark_node)
 	    return error_mark_node;
 	}
@@ -4143,8 +4143,8 @@ build_vec_delete_1 (location_t loc, tree base, tree maxindex, tree type,
     return error_mark_node;
   body = build_compound_expr (loc, body, tmp);
   tmp = build_delete (loc, ptype, tbase, sfk_complete_destructor,
-		      LOOKUP_NORMAL|LOOKUP_DESTRUCTOR, 1,
-		      complain);
+		      LOOKUP_NORMAL|LOOKUP_DESTRUCTOR|LOOKUP_NONVIRTUAL,
+		      1, complain);
   if (tmp == error_mark_node)
     return error_mark_node;
   body = build_compound_expr (loc, body, tmp);

--- a/gcc/cp/parser.cc
+++ b/gcc/cp/parser.cc
@@ -7967,10 +7967,25 @@ cp_parser_postfix_expression (cp_parser *parser, bool address_p, bool cast_p,
 		  }
 		else if (BASELINK_P (fn))
 		  {
+                  bool is_array_access = false;
+		  if (TREE_CODE (instance) == ARRAY_REF)
+		      is_array_access = true;
+		  if (INDIRECT_REF_P (instance))
+		  {
+		      tree expr = TREE_OPERAND (instance, 0);
+		      while (TREE_CODE (expr) == COMPOUND_EXPR)
+		      {
+			  expr = TREE_OPERAND (expr, 1);
+		      }
+		      if (TREE_CODE (expr) == POINTER_PLUS_EXPR)
+		      {
+			  is_array_access = true;
+		      }
+		  }
 		  postfix_expression
 		    = (build_new_method_call
 		       (instance, fn, &args, NULL_TREE,
-			(idk == CP_ID_KIND_QUALIFIED
+			(idk == CP_ID_KIND_QUALIFIED || is_array_access
 			 ? LOOKUP_NORMAL|LOOKUP_NONVIRTUAL
 			 : LOOKUP_NORMAL),
 			/*fn_p=*/NULL,

--- a/gcc/testsuite/g++.dg/devirt-array-access-1.C
+++ b/gcc/testsuite/g++.dg/devirt-array-access-1.C
@@ -1,0 +1,29 @@
+/* { dg-do run } */
+/* Virtual calls should be devirtualized because we know dynamic type of object in array at compile time */
+/* { dg-options "-O3 -fdump-tree-optimized -fno-inline"  } */
+
+class A
+{
+public:
+    virtual void f() {};
+};
+
+class B : public A
+{
+public:
+    virtual void f() {};
+};
+
+int __attribute__ ((noinline,noclone)) get_input(void)
+{
+    return 1;
+}
+
+int main()
+{
+    B b[10];
+    b[get_input()].f();
+    return 0;
+}
+
+/* { dg-final { scan-tree-dump-times "OBJ_TYPE_REF" 0 "optimized"} } */

--- a/gcc/testsuite/g++.dg/devirt-array-access-2.C
+++ b/gcc/testsuite/g++.dg/devirt-array-access-2.C
@@ -1,0 +1,30 @@
+/* { dg-do run } */
+/* Virtual calls should be devirtualized because we know dynamic type of object in array at compile time */
+/* { dg-options "-O3 -fdump-tree-optimized -fno-inline"  } */
+
+class A
+{
+public:
+    virtual void f() {};
+};
+
+class B : public A
+{
+public:
+    virtual void f() {};
+};
+
+int __attribute__ ((noinline,noclone)) get_input(void)
+{
+    return 1;
+}
+
+int main()
+{
+    B* b = new B[10];
+    b[get_input()].f();
+    delete[] b;
+    return 0;
+}
+
+/* { dg-final { scan-tree-dump-times "OBJ_TYPE_REF" 0 "optimized"} } */

--- a/gcc/testsuite/g++.dg/devirt-array-destructor-1.C
+++ b/gcc/testsuite/g++.dg/devirt-array-destructor-1.C
@@ -1,0 +1,27 @@
+/* { dg-do run } */
+/* Virtual calls should be devirtualized because we know dynamic type of object in array at compile time */
+/* { dg-options "-O3 -fdump-tree-optimized -fno-inline"  } */
+
+class A
+{
+public:
+  virtual ~A()
+  {
+  }
+};
+
+class B : public A
+{
+public:
+  virtual ~B()
+  {
+  }
+};
+
+int main()
+{
+  B b[10];
+  return 0;
+}
+
+/* { dg-final { scan-tree-dump-times "OBJ_TYPE_REF" 0 "optimized"} } */

--- a/gcc/testsuite/g++.dg/devirt-array-destructor-2.C
+++ b/gcc/testsuite/g++.dg/devirt-array-destructor-2.C
@@ -1,0 +1,28 @@
+/* { dg-do run } */
+/* Virtual calls should be devirtualized because we know dynamic type of object in array at compile time */
+/* { dg-options "-O3 -fdump-tree-optimized -fno-inline"  } */
+
+class A
+{
+public:
+  virtual ~A()
+  {
+  }
+};
+
+class B : public A
+{
+public:
+  virtual ~B()
+  {
+  }
+};
+
+int main()
+{
+  B* ptr = new B[10];
+  delete[] ptr;
+  return 0;
+}
+
+/* { dg-final { scan-tree-dump-times "OBJ_TYPE_REF" 0 "optimized"} } */

--- a/gcc/testsuite/g++.dg/warn/pr83054.C
+++ b/gcc/testsuite/g++.dg/warn/pr83054.C
@@ -10,7 +10,7 @@
 #endif
 
 extern "C" int printf (const char *, ...);
-struct foo // { dg-warning "final would enable devirtualization of 5 calls" }
+struct foo // { dg-warning "final would enable devirtualization of 1 call" }
 {
   static int count;
   void print (int i, int j) { printf ("foo[%d][%d] = %d\n", i, j, x); }
@@ -29,19 +29,15 @@ int foo::count;
 
 int main ()
 {
-  {
-    foo array[3][3];
-    for (int i = 0; i < 3; i++)
-      {
-	for (int j = 0; j < 3; j++)
-	  {
-	    printf("&a[%d][%d] = %x\n", i, j, (void *)&array[i][j]);
-	  }
-      }
-      // The count should be nine, if not, fail the test.
-      if (foo::count != 9)
-	return 1;
-  }
+  foo* arr[9];
+  for (int i = 0; i < 9; ++i)
+    arr[i] = new foo();
+  if (foo::count != 9)
+    return 1;
+  for (int i = 0; i < 9; ++i)
+    arr[i]->print(i / 3, i % 3);
+  for (int i = 0; i < 9; ++i)
+    delete arr[i];
   if (foo::count != 0)
     return 1;
   return 0;


### PR DESCRIPTION
Devirtualizes array access in the frontend.

Important stuff is in `parser.cc` even though I don't know if that is the best way to do things. The array destruction already is fixed.

TODO: attempt to implement similar idea in the optimizer so that it is able to perform optimization after inlining